### PR TITLE
change "separates two selectors" to "separates two elements"

### DIFF
--- a/files/en-us/web/css/adjacent_sibling_combinator/index.html
+++ b/files/en-us/web/css/adjacent_sibling_combinator/index.html
@@ -11,7 +11,7 @@ browser-compat: css.selectors.adjacent_sibling
 ---
 <div>{{CSSRef("Selectors")}}</div>
 
-<p>The <strong>adjacent sibling combinator</strong> (<code>+</code>) separates two selectors and matches the second element only if it <em>immediately</em> follows the first element, and both are children of the same parent {{DOMxRef("element")}}.</p>
+<p>The <strong>adjacent sibling combinator</strong> (<code>+</code>) separates two elements and matches the second element only if it <em>immediately</em> follows the first element, and both are children of the same parent {{DOMxRef("element")}}.</p>
 
 <pre class="brush: css no-line-numbers">/* Paragraphs that come immediately after any image */
 img + p {


### PR DESCRIPTION
<!-- Please provide the following information to help us review this PR: -->

> What was wrong/why is this fix needed? (quick summary only)

Maybe the wrong word. And easily overlooked. This selector separates two elements. :)

> Issue number (if there is an associated issue)

None.

> Anything else that could help us review it
